### PR TITLE
Fix AI summary generation in overview report

### DIFF
--- a/cfo-frontend/src/components/report/OverviewTab.jsx
+++ b/cfo-frontend/src/components/report/OverviewTab.jsx
@@ -184,13 +184,25 @@ export default function OverviewTab({ runId }) {
               Get personalized insights based on your diagnostic results.
               Our AI will analyze your data and may ask a few targeted questions to refine the analysis.
             </p>
+            {/* Display error if pipeline failed before starting */}
+            {error && (
+              <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-sm">
+                <div className="flex items-start gap-2">
+                  <AlertTriangle className="w-4 h-4 text-red-500 mt-0.5 flex-shrink-0" />
+                  <div>
+                    <p className="text-sm text-red-700 font-medium">Failed to generate analysis</p>
+                    <p className="text-xs text-red-600 mt-1">{error}</p>
+                  </div>
+                </div>
+              </div>
+            )}
             <button
               onClick={handleStart}
               disabled={isStarting}
               className="px-6 py-2.5 bg-blue-600 text-white text-sm font-medium rounded-sm hover:bg-blue-700 transition-colors flex items-center gap-2 disabled:opacity-50"
             >
               <Sparkles className="w-4 h-4" />
-              {isStarting ? 'Starting...' : 'Generate Analysis'}
+              {isStarting ? 'Starting...' : error ? 'Retry Analysis' : 'Generate Analysis'}
             </button>
           </div>
         </div>

--- a/src/interpretation/agents/generator.ts
+++ b/src/interpretation/agents/generator.ts
@@ -41,6 +41,9 @@ const MAX_GENERATION_ATTEMPTS = 2;
 let _openai: OpenAI | null = null;
 function getOpenAI(): OpenAI {
   if (!_openai) {
+    if (!process.env.OPENAI_API_KEY) {
+      throw new Error('OPENAI_API_KEY environment variable is not set. AI summary generation requires a valid OpenAI API key.');
+    }
     _openai = new OpenAI();
   }
   return _openai;

--- a/src/interpretation/pipeline-vs32c.ts
+++ b/src/interpretation/pipeline-vs32c.ts
@@ -255,9 +255,13 @@ export async function runVS32cPipeline(
 
   try {
     // Run the pipeline loop
+    console.log('[VS-32c] Starting pipeline for run:', input.run_id);
     return await executePipelineLoop(supabase, state, input);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
+    const stack = error instanceof Error ? error.stack : '';
+    console.error('[VS-32c] Pipeline failed:', message);
+    console.error('[VS-32c] Stack trace:', stack);
     await updateState(supabase, input.run_id, { current_stage: 'failed' });
     return {
       status: 'failed',

--- a/src/interpretation/precompute.ts
+++ b/src/interpretation/precompute.ts
@@ -83,9 +83,11 @@ export async function precomputeInput(
   // 3. Load spec
   let spec;
   try {
+    console.log('[VS-32c Precompute] Loading spec version:', typedRun.spec_version);
     spec = SpecRegistry.get(typedRun.spec_version);
   } catch (err) {
-    throw new Error(`Failed to load spec: ${err}`);
+    console.error('[VS-32c Precompute] Failed to load spec:', typedRun.spec_version, err);
+    throw new Error(`Failed to load spec (version: ${typedRun.spec_version}): ${err}`);
   }
 
   // 4. Calculate maturity using calculateMaturityV2

--- a/src/specs/registry.ts
+++ b/src/specs/registry.ts
@@ -24,9 +24,15 @@ const REGISTRY: Record<SpecVersion, () => Spec> = {
 
 export const SpecRegistry = {
   get(version: string): Spec {
-    const specFn = REGISTRY[version as SpecVersion];
+    // Normalize version: add 'v' prefix if missing
+    let normalizedVersion = version;
+    if (version && !version.startsWith('v')) {
+      normalizedVersion = `v${version}`;
+    }
+
+    const specFn = REGISTRY[normalizedVersion as SpecVersion];
     if (!specFn) {
-      throw new Error(`Spec version not found: ${version}`);
+      throw new Error(`Spec version not found: ${version} (normalized: ${normalizedVersion})`);
     }
     return specFn();
   },


### PR DESCRIPTION
- SpecRegistry: Handle spec versions without 'v' prefix (e.g., "2.9.0" -> "v2.9.0")
- OverviewTab: Display error message when pipeline fails before starting
- Generator: Add explicit check for OPENAI_API_KEY with helpful error message
- Pipeline: Add console logging for debugging pipeline failures
- Precompute: Add logging for spec version loading

These changes fix issues where:
1. Diagnostic runs with spec_version stored without 'v' prefix would fail silently
2. Error messages were not displayed to users when pipeline failed immediately
3. Missing OpenAI API key caused cryptic errors